### PR TITLE
use parseToNodes in parse. Handle a special attribute case explicitly

### DIFF
--- a/src/SvgParser.elm
+++ b/src/SvgParser.elm
@@ -307,6 +307,7 @@ parseToNode input =
 
 
 {-| Parses `String` to `Html msg`. This function filters top level comments to find the first `<svg>` element.
+Additional `<svg>` elements are ignored.
 -}
 parse : String -> Result String (Html msg)
 parse input =


### PR DESCRIPTION
This builds on https://github.com/Garados007/elm-svg-parser/pull/2 to

- use the `parseToNodes` in `parse`; and 
- handle a special attribute case explicitly