### PR TITLE
Add support for DOCTYPE declarations

### DIFF
--- a/src/SvgParser.elm
+++ b/src/SvgParser.elm
@@ -262,6 +262,14 @@ xmlDeclarationParser =
         )
 
 
+{-| Parse DOCTYPE declaration
+-}
+doctypeDeclarationParser : Parser s String
+doctypeDeclarationParser =
+    andMapRight whitespace <|
+        regex "<!DOCTYPE(?:\"(?:\\\\.|[^\"])*\"|'(?:\\\\.|[^'])*'|[^>])*>"
+
+
 {-| Same as parseToNode, but returns a list of all the nodes in the string.
 -}
 parseToNodes : String -> Result String (List SvgNode)
@@ -270,7 +278,10 @@ parseToNodes input =
         Combine.runParser
             (andMapRight
                 (optional "" xmlDeclarationParser)
-                (many nodeParser)
+                (andMapRight
+                    (optional "" doctypeDeclarationParser)
+                    (many nodeParser)
+                )
             )
             []
             input
@@ -294,7 +305,9 @@ parseToNode input =
         Combine.runParser
             (andMapRight
                 (optional "" xmlDeclarationParser)
-                nodeParser
+                (andMapRight (optional "" doctypeDeclarationParser)
+                    nodeParser
+                )
             )
             []
             input

--- a/tests/Cases.elm
+++ b/tests/Cases.elm
@@ -22,6 +22,26 @@ withVersionElement =
         []
 
 
+withDoctypeString : String
+withDoctypeString =
+    """
+<?xml version="1.0" ?>
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.0//EN'  'http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd'>
+<svg width="24" height="24" viewBox="0 0 24 24">
+</svg>
+    """
+
+
+withDoctypeElement : Element
+withDoctypeElement =
+    Element "svg"
+        [ ( "width", "24" )
+        , ( "height", "24" )
+        , ( "viewBox", "0 0 24 24" )
+        ]
+        []
+
+
 motorcycleIcon : String
 motorcycleIcon =
     """
@@ -77,5 +97,6 @@ motorcycleElement =
 
 all =
     [ ( "with version doc", withVersionDoc, withVersionElement )
+    , ( "with doctype", withDoctypeString, withDoctypeElement )
     , ( "motocycle icon", motorcycleIcon, motorcycleElement )
     ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,7 +1,7 @@
 module Tests exposing (suite, testParseToNode)
 
 import Cases exposing (all)
-import Expect exposing (Expectation)
+import Expect
 import SvgParser exposing (..)
 import Test exposing (..)
 


### PR DESCRIPTION
The svg source code may contain DOCTYPE declarations that are silently
ignored by the parser.

Specification: https://www.w3.org/TR/SVG11/struct.html

Close: Garados007/elm-svg-parser#10